### PR TITLE
Add CUDA support for low-level field arithmetic

### DIFF
--- a/gpu-poly/src/cuda/fft.cu
+++ b/gpu-poly/src/cuda/fft.cu
@@ -1,0 +1,140 @@
+#include <stdio.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <cuda.h>
+#include "frarith.h"
+#include <iostream>
+
+
+/*==================== CUDA KERNELS ====================*/
+
+/*
+	Inner FFT loop
+*/
+__device__ void inplace_fft_inner(uint64_t *__restrict__ A, uint64_t *__restrict__ tw, int j, int k, int m, int n) {
+	if (j + k + m / 2 < n && k < m / 2) {
+		unsigned r = j + k + m / 2;
+		unsigned l = j + k;
+		unsigned g = k * (n / m);
+
+		Mul(A + (r << 2), tw + (g << 2), A + (r << 2));
+
+		uint64_t t[4]{
+			A[(l << 2) + 0],
+			A[(l << 2) + 1],
+			A[(l << 2) + 2],
+			A[(l << 2) + 3]
+		};
+
+		Add(A + (l << 2), A + (r << 2), A + (l << 2));
+		Sub(t, A + (r << 2), A + (r << 2));
+	}
+}
+
+/*
+	Reorders array by bit-reversing the indices
+*/
+__global__ void bit_reverse(uint64_t *__restrict__ A, uint64_t *__restrict__ tmp, int s, size_t nthr) {
+	int id = blockIdx.x * nthr + threadIdx.x;
+	int n = 1 << s;
+	int shifted = __brev(id) >> (32 - s);
+	if (id < n && shifted < n) {
+		A[shifted * 4 + 0] = tmp[id * 4 + 0];
+		A[shifted * 4 + 1] = tmp[id * 4 + 1];
+		A[shifted * 4 + 2] = tmp[id * 4 + 2];
+		A[shifted * 4 + 3] = tmp[id * 4 + 3];
+	}
+}
+
+/*
+	FFT if we have enough threads
+*/
+__global__ void inplace_fft(uint64_t *__restrict__ A, uint64_t *__restrict__ tw, int j, int m, int n, size_t nthr) {
+	int k = blockIdx.x * nthr + threadIdx.x;
+	inplace_fft_inner(A, tw, j, k, m, n);
+}
+
+/*
+	FFT if we don't have enough threads
+*/
+__global__ void inplace_fft_outer(uint64_t *__restrict__ A, uint64_t *__restrict__ tw, int m, int n, size_t nthr) {
+	int j = (blockIdx.x * nthr + threadIdx.x) * m;
+	for (int k = 0; k < m / 2; k++) {
+		inplace_fft_inner(A, tw, j, k, m, n);
+	}
+}
+
+// #define CHECK_LAST_CUDA_ERROR() checkLast(__FILE__, __LINE__)
+// void checkLast(const char* const file, const int line)
+// {
+//     cudaError_t err{cudaGetLastError()};
+//     if (err != cudaSuccess)
+//     {
+//         std::cerr << "CUDA Runtime Error at: " << file << ":" << line
+//                   << std::endl;
+//         std::cerr << cudaGetErrorString(err) << std::endl;
+//         // We don't exit when we encounter CUDA errors in this example.
+//         // std::exit(EXIT_FAILURE);
+//     }
+// }
+
+extern "C" {
+	void fft(uint64_t *a, uint64_t *omegas, size_t n, bool invert, int balance, size_t threads) {
+		// NOTE: n is the number of ELEMENTS,
+		// The total list size is n * S
+		uint64_t list_size = n * S;
+		
+		// Create array from input vector
+		uint64_t buffer_size = list_size * sizeof(uint64_t);
+
+		// Allocate array
+		uint64_t *data_array = (uint64_t *) malloc(buffer_size);
+		for (int i = 0; i < list_size; i++) {
+			data_array[i] = a[i];
+		}
+
+		// Copy data to FPGA using 2 arrays for bitreverse
+		uint64_t *A, *tmp, *tw;
+		cudaMalloc((void **) &A, buffer_size);
+		cudaMalloc((void **) &tmp, buffer_size);
+		cudaMalloc((void **) &tw, buffer_size); // TODO: I think this will/can be smaller than buffer_size 
+		cudaMemcpy(tmp, data_array, buffer_size, cudaMemcpyHostToDevice);
+		cudaMemcpy(tw, omegas, buffer_size / 2, cudaMemcpyHostToDevice);
+
+		// Bit reverse ordering
+		int s = log2(n);
+		bit_reverse<<<ceil((float)n / threads), threads>>>(A, tmp, s, threads);
+		
+		// Synchronize 
+		cudaDeviceSynchronize();
+		// Iterative FFT with loop parallelism balancing
+		for (int i = 1; i <= s; i++) {
+			int m = 1 << i;
+			if (n / m > balance) {
+				inplace_fft_outer<<<ceil((float)n / m / threads), threads>>>(A, tw, m, n, threads);
+			} else {
+				for (int j = 0; j < n; j += m) {
+					float repeats = m / 2;
+					inplace_fft<<<ceil(repeats / threads), threads>>>(A, tw, j, m, n, threads);
+				}
+			}
+		}
+
+		// Copy back result
+		uint64_t *result;
+		result = (uint64_t *) malloc(buffer_size);
+		cudaMemcpy(result, A, buffer_size, cudaMemcpyDeviceToHost);
+
+		for (int i = 0; i < list_size; i++) {
+			a[i] = result[i];
+		}
+
+		free(data_array);
+		free(result);
+		cudaFree(A);
+		cudaFree(tmp);
+		cudaFree(tw);
+
+		return;
+	}
+}

--- a/gpu-poly/src/cuda/includes/bn254.h
+++ b/gpu-poly/src/cuda/includes/bn254.h
@@ -1,0 +1,33 @@
+#ifndef __BN254_H__
+#define __BN254_H__
+
+// K -> Num bits to store a field element
+#define K 256
+
+// S -> Number of words to store a field element
+#define S 4
+
+#include <cuda.h>
+
+// Constants for BN254
+__device__ uint64_t MODULUS[S]{
+	4891460686036598785,
+	2896914383306846353,
+	13281191951274694749,
+	3486998266802970665
+};
+__device__ uint64_t R[S]{
+	12436184717236109307,
+	3962172157175319849,
+	7381016538464732718,
+	1011752739694698287
+};
+__device__ uint64_t UNITY[S]{
+	7164790868263648668,
+	11685701338293206998,
+	6216421865291908056,
+	1756667274303109607
+};
+__device__ uint64_t montConstant = 14042775128853446655;
+
+#endif

--- a/gpu-poly/src/cuda/includes/frarith.h
+++ b/gpu-poly/src/cuda/includes/frarith.h
@@ -1,0 +1,299 @@
+#ifndef __FR_ARITH_H__
+#define __FR_ARITH_H__
+
+#define LO 1
+#define HI 0
+#define SUM 0
+#define CARRY 1
+#define DIFF 0
+#define BORROW 1
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <cuda.h>
+
+#include "bn254.h"
+
+/*=============== DEVICE FUNCTIONS =================*/
+/* Modulus Arithmetic */
+static __device__ inline void Add64(uint64_t a, uint64_t b, uint64_t carry, uint64_t *result) {
+	uint64_t sum = a + b + carry;
+	carry = ((a & b) | ((a | b) & ~sum)) >> 63;
+
+	result[SUM] = sum;
+	result[CARRY] = carry;
+}
+
+static __device__ inline void Sub64(uint64_t a, uint64_t b, uint64_t borrow, uint64_t *result) {
+	uint64_t diff = a - b - borrow;
+	borrow = ((~a & b) | (~(a ^ b) & diff)) >> 63;
+
+	result[DIFF] = diff;
+	result[BORROW] = borrow;
+}
+
+static __device__ inline void Mul64(uint64_t a, uint64_t b, uint64_t *result) {
+	const uint64_t one = 1;
+	const uint64_t mask32 = (one << 32) - 1;
+	uint64_t a0 = a & mask32;
+	uint64_t a1 = a >> 32;
+	uint64_t b0 = b & mask32;
+	uint64_t b1 = b >> 32;
+	
+	uint64_t w0 = a0 * b0;
+	uint64_t t = a1 * b0 + (w0 >> 32);
+	uint64_t w1 = t & mask32;
+	uint64_t w2 = t >> 32;
+	w1 += a0 * b1;
+
+	result[HI] = a1 * b1 + w2 + (w1 >> 32);
+	result[LO] = a * b;
+}
+
+static __device__ inline void madd0(uint64_t a, uint64_t b, uint64_t c, uint64_t &hi) {
+	uint64_t mul_result[2];
+	Mul64(a, b, mul_result);
+
+	uint64_t add_result[2];
+	Add64(mul_result[LO], c, 0, add_result);
+
+	uint64_t add_result_2[2];
+	Add64(mul_result[HI], 0, add_result[CARRY], add_result_2);
+
+	hi = add_result_2[SUM];
+}
+
+static __device__ inline void madd1(uint64_t a, uint64_t b, uint64_t c, uint64_t &hi, uint64_t &lo) {
+	uint64_t mul_result[2];
+	Mul64(a, b, mul_result);
+
+	uint64_t add_result[2];
+	Add64(mul_result[LO], c, 0, add_result);
+
+	uint64_t add_result_2[2];
+	Add64(mul_result[HI], 0, add_result[CARRY], add_result_2);
+
+	hi = add_result_2[SUM];
+	lo = add_result[SUM];
+}
+
+static __device__ inline void madd2(uint64_t a, uint64_t b, uint64_t c, uint64_t d, uint64_t &hi, uint64_t &lo) {
+	uint64_t mul_result[2];
+	Mul64(a, b, mul_result);
+
+	uint64_t add_result[2];
+	Add64(c, d, 0, add_result);
+
+	uint64_t add_result_2[2];
+	Add64(mul_result[HI], 0, add_result[CARRY], add_result_2);
+	
+	uint64_t add_result_3[2];
+	Add64(mul_result[LO], add_result[SUM], 0, add_result_3);
+
+	uint64_t add_result_4[2];
+	Add64(add_result_2[SUM], 0, add_result_3[CARRY], add_result_4);
+
+	hi = add_result_4[SUM];
+	lo = add_result_3[SUM];
+}
+
+static __device__ inline void madd3(uint64_t a, uint64_t b, uint64_t c, uint64_t d, uint64_t e, uint64_t &hi, uint64_t &lo) {
+	uint64_t mul_result[2];
+	Mul64(a, b, mul_result);
+
+	uint64_t add_result[2];
+	Add64(c, d, 0, add_result);
+
+	uint64_t add_result_2[2];
+	Add64(mul_result[HI], 0, add_result[CARRY], add_result_2);
+
+	uint64_t add_result_3[2];
+	Add64(mul_result[LO], add_result[SUM], 0, add_result_3);
+
+	uint64_t add_result_4[2];
+	Add64(add_result_2[SUM], e, add_result_3[CARRY], add_result_4);
+
+	hi = add_result_4[SUM];
+	lo = add_result_3[SUM];
+}
+
+static __device__ inline bool smallerThanModulus(uint64_t* z) {
+	return (
+		(z[3] < MODULUS[3] || 
+		(z[3] == MODULUS[3] && 
+		(z[2] < MODULUS[2] || 
+		(z[2] == MODULUS[2] && 
+		(z[1] < MODULUS[1] || 
+		(z[1] == MODULUS[1] && 
+		(z[0] < MODULUS[0])))))))
+	);
+}
+
+static __device__ inline void Add(uint64_t *a, uint64_t* b, uint64_t* out) {
+	uint64_t carry = 0;
+	uint64_t add_container[2];
+
+	Add64(a[0], b[0], carry, add_container);
+	out[0] = add_container[SUM];
+	carry = add_container[CARRY];
+
+	Add64(a[1], b[1], carry, add_container);
+	out[1] = add_container[SUM];
+	carry = add_container[CARRY];
+
+	Add64(a[2], b[2], carry, add_container);
+	out[2] = add_container[SUM];
+	carry = add_container[CARRY];
+
+	Add64(a[3], b[3], carry, add_container);
+	out[3] = add_container[SUM];
+
+	// Reduce if necessary
+	if (!smallerThanModulus(out)) {
+		uint64_t borrow = 0;
+		uint64_t sub_container[2];
+
+		Sub64(out[0], MODULUS[0], borrow, sub_container);
+		out[0] = sub_container[DIFF];
+		borrow = sub_container[BORROW];
+
+		Sub64(out[1], MODULUS[1], borrow, sub_container);
+		out[1] = sub_container[DIFF];
+		borrow = sub_container[BORROW];
+
+		Sub64(out[2], MODULUS[2], borrow, sub_container);
+		out[2] = sub_container[DIFF];
+		borrow = sub_container[BORROW];
+
+		Sub64(out[3], MODULUS[3], borrow, sub_container);
+		out[3] = sub_container[DIFF];
+	}
+}
+
+static __device__ inline void Sub(uint64_t* a, uint64_t* b, uint64_t* out) {
+	uint64_t borrow = 0;
+	uint64_t sub_container[2];
+
+	Sub64(a[0], b[0], borrow, sub_container);
+	out[0] = sub_container[DIFF];
+	borrow = sub_container[BORROW];
+
+	Sub64(a[1], b[1], borrow, sub_container);
+	out[1] = sub_container[DIFF];
+	borrow = sub_container[BORROW];
+
+	Sub64(a[2], b[2], borrow, sub_container);
+	out[2] = sub_container[DIFF];
+	borrow = sub_container[BORROW];
+
+	Sub64(a[3], b[3], borrow, sub_container);
+	out[3] = sub_container[DIFF];
+	borrow = sub_container[BORROW];
+
+	if (borrow != 0) {
+		uint64_t carry = 0;
+		uint64_t add_container[2];
+
+		Add64(out[0], MODULUS[0], carry, add_container);
+		out[0] = add_container[SUM];
+		carry = add_container[CARRY];
+
+		Add64(out[1], MODULUS[1], carry, add_container);
+		out[1] = add_container[SUM];
+		carry = add_container[CARRY];
+
+		Add64(out[2], MODULUS[2], carry, add_container);
+		out[2] = add_container[SUM];
+		carry = add_container[CARRY];
+
+		Add64(out[3], MODULUS[3], carry, add_container);
+		out[3] = add_container[SUM];
+	}
+}
+
+static __device__ inline void Mul(uint64_t* a, uint64_t* b, uint64_t* out) {
+	// Implements CIOS multiplication -- section 2.3.2 of Tolga Acar's thesis
+	// https://www.microsoft.com/en-us/research/wp-content/uploads/1998/06/97Acar.pdf
+
+	uint64_t t[4]{0, 0, 0, 0};
+	uint64_t c[3]{0, 0, 0};
+
+	{
+		// round 0
+		uint64_t v = a[0];
+		uint64_t mul_container[2];
+		Mul64(v, b[0], mul_container);
+		c[1] = mul_container[HI];
+		c[0] = mul_container[LO];
+
+		uint64_t m = c[0] * montConstant;
+		madd0(m, MODULUS[0], c[0], c[2]);
+		madd1(v, b[1], c[1], c[1], c[0]);
+		madd2(m, MODULUS[1], c[2], c[0], c[2], t[0]);
+		madd1(v, b[2], c[1], c[1], c[0]);
+		madd2(m, MODULUS[2], c[2], c[0], c[2], t[1]);
+		madd1(v, b[3], c[1], c[1], c[0]);
+		madd3(m, MODULUS[3], c[0], c[2], c[1], t[3], t[2]);
+	}
+	{
+		// round 1
+		uint64_t v = a[1];
+		madd1(v, b[0], t[0], c[1], c[0]);
+		uint64_t m = c[0] * montConstant;
+		madd0(m, MODULUS[0], c[0], c[2]);
+		madd2(v, b[1], c[1], t[1], c[1], c[0]);
+		madd2(m, MODULUS[1], c[2], c[0], c[2], t[0]);
+		madd2(v, b[2], c[1], t[2], c[1], c[0]);
+		madd2(m, MODULUS[2], c[2], c[0], c[2], t[1]);
+		madd2(v, b[3], c[1], t[3], c[1], c[0]);
+		madd3(m, MODULUS[3], c[0], c[2], c[1], t[3], t[2]);
+	}
+	{
+		// round 2
+		uint64_t v = a[2];
+		madd1(v, b[0], t[0], c[1], c[0]);
+		uint64_t m = c[0] * montConstant;
+		madd0(m, MODULUS[0], c[0], c[2]);
+		madd2(v, b[1], c[1], t[1], c[1], c[0]);
+		madd2(m, MODULUS[1], c[2], c[0], c[2], t[0]);
+		madd2(v, b[2], c[1], t[2], c[1], c[0]);
+		madd2(m, MODULUS[2], c[2], c[0], c[2], t[1]);
+		madd2(v, b[3], c[1], t[3], c[1], c[0]);
+		madd3(m, MODULUS[3], c[0], c[2], c[1], t[3], t[2]);
+	}
+	{
+		// round 3
+		uint64_t v = a[3];
+		madd1(v, b[0], t[0], c[1], c[0]);
+		uint64_t m = c[0] * montConstant;
+		madd0(m, MODULUS[0], c[0], c[2]);
+		madd2(v, b[1], c[1], t[1], c[1], c[0]);
+		madd2(m, MODULUS[1], c[2], c[0], c[2], out[0]);
+		madd2(v, b[2], c[1], t[2], c[1], c[0]);
+		madd2(m, MODULUS[2], c[2], c[0], c[2], out[1]);
+		madd2(v, b[3], c[1], t[3], c[1], c[0]);
+		madd3(m, MODULUS[3], c[0], c[2], c[1], out[3], out[2]);
+	}
+
+	//if z >= q → z -= q
+	if (!smallerThanModulus(out)) {
+		uint64_t borrow = 0;
+		uint64_t sub_container[2];
+
+		Sub64(out[0], MODULUS[0], borrow, sub_container);
+		out[0] = sub_container[DIFF];
+		borrow = sub_container[BORROW];
+
+		Sub64(out[1], MODULUS[1], borrow, sub_container);
+		out[1] = sub_container[DIFF];
+		borrow = sub_container[BORROW];
+
+		Sub64(out[2], MODULUS[2], borrow, sub_container);
+		out[2] = sub_container[DIFF];
+		borrow = sub_container[BORROW];
+
+		Sub64(out[3], MODULUS[3], borrow, sub_container);
+		out[3] = sub_container[DIFF];
+	}
+}
+#endif


### PR DESCRIPTION
## Motivation
Currently miniSTARK supports the Metal API to provide GPU-based hardware acceleration for Apple's new ARM-based SoC GPUs. GPU acceleration is not currently supported for users outside the Apple ecosystem using NVIDIA GPUs. 

## What
This draft PR contains some basic CUDA based IP for FFTs and field arithmetic over the BN254 curve. Further, we want to explore to what extend both the CUDA and Metal implementations can overlap. 

## Subsequent Work
Additional comments and commits are welcome while we add CUDA support one-to-one with Metal.